### PR TITLE
dependabot의 PR을 자동으로 머지하는 기능 추가

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,16 @@
+name: auto-merge-dependabot
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: squalrus/merge-bot@v0.1.0
+        if: github.actor == "dependabot[bot]"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labels: dependencies
+          delete_source_branch: true


### PR DESCRIPTION
Close #12

pull_request, type: opend 의 PR이 왔을 때 자동으로 실행되는 코드입니다.

merge-bot을 사용하고, github의 actor이 dependabot[bot] 일 경우 자동으로 머지합니다.﻿
