### PR TITLE
본문 스타일을 수정

### DIFF
--- a/src/components/post/Content.ts
+++ b/src/components/post/Content.ts
@@ -5,6 +5,7 @@ const Content = styled.article`
   white-space: pre-line;
   line-height: 1;
   font-size: 17px;
+  word-break: keep-all;
 
   code {
     line-height: 1.2;

--- a/src/components/post/Content.ts
+++ b/src/components/post/Content.ts
@@ -39,6 +39,15 @@ const Content = styled.article`
   p {
     line-height: 1.5;
   }
+
+  * {
+    margin: 0;
+    padding: 0;
+  }
+
+  ul {
+    list-style-position: inside;
+  }
 `;
 
 export default Content;

--- a/src/components/post/Content.ts
+++ b/src/components/post/Content.ts
@@ -45,6 +45,10 @@ const Content = styled.article`
     padding: 0;
   }
 
+  code {
+    padding: 2px 5px;
+  }
+
   ul {
     list-style-position: inside;
   }

--- a/src/components/post/Content.ts
+++ b/src/components/post/Content.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const Content = styled.article`
   padding: 0 0 100px 0;
   white-space: pre-line;
-  line-height: 1.5;
+  line-height: 1;
   font-size: 17px;
 
   code {
@@ -34,6 +34,10 @@ const Content = styled.article`
 
   img {
     max-width: 100%;
+  }
+
+  p {
+    line-height: 1.5;
   }
 `;
 

--- a/src/components/renderer/index.tsx
+++ b/src/components/renderer/index.tsx
@@ -12,13 +12,15 @@ import { Figure, FigCaption } from "../post/Figure";
 const remarkPlugins = [unwrapImages];
 
 const components: Components = {
-  code({ className, children }) {
+  code({ inline, className, children }) {
     const language = className?.split("-")[1];
     const code = String(children).replace(/\n$/, "") || "";
-    return (
+    return !inline ? (
       <SyntaxHighlighter language={language} style={prism}>
         {code}
       </SyntaxHighlighter>
+    ) : (
+      <code>{code}</code>
     );
   },
   img({ src, alt }) {


### PR DESCRIPTION
- 💄 line-height를 본문에만 적용하도록 변경
- 💄 모든 element의 margin과 padding을 0으로 설정
- 🐛 inline code까지 code block으로 작성되는 버그 해결
- 💄 inline code 태그에 padding을 추가
- 💄 word-break: keep-all을 적용
