### PR TITLE
SEO를 위한 Meta 태그 추가

### DIFF
--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import React from "react";
 
 // SITE ROOT
@@ -76,6 +77,15 @@ export const OgArticle = ({
   section,
   tags,
 }: OgArticleProps) => {
+  publishedDate = format(
+    new Date(publishedDate),
+    `yyyy-MM-dd'T'HH:mm:ss.000+09:00`,
+  );
+  modifiedDate = format(
+    new Date(modifiedDate),
+    `yyyy-MM-dd'T'HH:mm:ss.000+09:00`,
+  );
+
   return (
     <>
       <meta property="og:type" content="article" />

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+
+// SITE ROOT
+const CANONICAL = "https://pinot.kim";
+
+interface DefaultProps {
+  title: string;
+  url: string;
+  image: string;
+  description: string;
+}
+
+export enum ROBOTS {
+  // 검색 O / 하위 링크 검색 O
+  "INDEX_FOLLOW" = "index,follow",
+  // 검색 X / 하위 링크 검색 O
+  "NOINDEX_FOLLOW" = "noindex,follow",
+  // 검색 O / 하위 링크 검색 X
+  "INDEX_NOFILLOW" = "index,nofollow",
+  // 검색 X / 하위 링크 검색 X
+  "NOINDEX_NOFOLLOW" = "noindex,nofollow",
+}
+
+export function titleTemplate(title: string) {
+  return `${title} | PLOG`;
+}
+
+interface MetaProps extends DefaultProps {
+  author: string;
+  robots?: ROBOTS;
+}
+
+const PLOGMeta = ({ title, description, author, robots }: MetaProps) => {
+  return (
+    <>
+      {/* DEFAULT */}
+      <meta name="title" content={titleTemplate(title)} />
+      <meta name="description" content={description} />
+      <meta name="author" content={author} />
+      <meta name="robots" content={robots || ROBOTS.INDEX_FOLLOW} />
+      {/* ETC */}
+      <link rel="canonical" href={CANONICAL} />
+      <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+    </>
+  );
+};
+
+export const OgWebsite = ({ title, url, image, description }: DefaultProps) => {
+  return (
+    <>
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={titleTemplate(title)} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:description" content={description} />
+    </>
+  );
+};
+
+interface OgArticleProps extends DefaultProps {
+  publishedDate: string;
+  modifiedDate: string;
+  section: string;
+  tags: string[];
+  author: string;
+}
+
+export const OgArticle = ({
+  url,
+  image,
+  title,
+  description,
+  author,
+  publishedDate,
+  modifiedDate,
+  section,
+  tags,
+}: OgArticleProps) => {
+  return (
+    <>
+      <meta property="og:type" content="article" />
+      <meta property="og:title" content={titleTemplate(title)} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:description" content={description} />
+      <meta property="article:author" content={author} />
+      <meta property="article:published_time" content={publishedDate} />
+      <meta property="article:modified_time" content={modifiedDate} />
+      <meta property="article:section" content={section} />
+      {tags.map((tag) => (
+        <meta property="article:tag" key={tag} content={tag} />
+      ))}
+    </>
+  );
+};
+
+interface TwitterCardProps extends DefaultProps {
+  large: boolean;
+  imageAlt: string;
+}
+
+export const TwitterCard = ({
+  large,
+  title,
+  description,
+  image,
+  imageAlt,
+}: TwitterCardProps) => {
+  const CARD_TYPE = large ? "summary_large_image" : "summary";
+
+  return (
+    <>
+      <meta name="twitter:card" content={CARD_TYPE} />
+      <meta name="twitter:title" content={titleTemplate(title)} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      <meta name="twitter:image:alt" content={imageAlt} />
+      <meta name="twitter:site" content="@pinot.kim" />
+    </>
+  );
+};
+
+export default PLOGMeta;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,6 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { Provider } from "next-auth/client";
 import { Router } from "next/router";
 import _nProgress from "nprogress";
-import Head from "next/head";
 
 const nProgress = _nProgress.configure({
   showSpinner: false,
@@ -31,24 +30,6 @@ const MyApp: NextComponentType<AppContext, AppInitialProps, AppProps> = ({
 }) => {
   return (
     <Provider session={pageProps.session}>
-      <Head>
-        <title>PLOG | PINOT 기술 블로그</title>
-        <meta name="title" content="PLOG" />
-        <meta name="description" content="PINOT 기술 블로그" />
-        <meta name="og:url" content="https://pinot.kim" />
-        <meta name="og:type" content="website" />
-        <meta name="og:title" content="PLOG" />
-        <meta name="og:site_name" content="PLOG" />
-        <meta name="og:description" content="PINOT 기술 블로그" />
-        <meta name="twitter:card" content="" />
-        <meta name="twitter:url" content="https://pinot.kim" />
-        <meta name="twitter:title" content="PLOG" />
-        <meta name="twitter:description" content="PINOT 기술 블로그" />
-        <link rel="canonical" href="https://pinot.kim" />
-        <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-        <meta name="robots" content="index,follow" />
-        <meta name="author" content="PINOT. KIM." />
-      </Head>
       <GlobalStyle />
       <Component {...pageProps} />
     </Provider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { Provider } from "next-auth/client";
 import { Router } from "next/router";
 import _nProgress from "nprogress";
+import Head from "next/head";
 
 const nProgress = _nProgress.configure({
   showSpinner: false,
@@ -30,6 +31,24 @@ const MyApp: NextComponentType<AppContext, AppInitialProps, AppProps> = ({
 }) => {
   return (
     <Provider session={pageProps.session}>
+      <Head>
+        <title>PLOG | PINOT 기술 블로그</title>
+        <meta name="title" content="PLOG" />
+        <meta name="description" content="PINOT 기술 블로그" />
+        <meta name="og:url" content="https://pinot.kim" />
+        <meta name="og:type" content="website" />
+        <meta name="og:title" content="PLOG" />
+        <meta name="og:site_name" content="PLOG" />
+        <meta name="og:description" content="PINOT 기술 블로그" />
+        <meta name="twitter:card" content="" />
+        <meta name="twitter:url" content="https://pinot.kim" />
+        <meta name="twitter:title" content="PLOG" />
+        <meta name="twitter:description" content="PINOT 기술 블로그" />
+        <link rel="canonical" href="https://pinot.kim" />
+        <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="robots" content="index,follow" />
+        <meta name="author" content="PINOT. KIM." />
+      </Head>
       <GlobalStyle />
       <Component {...pageProps} />
     </Provider>

--- a/src/pages/detail/[postId].tsx
+++ b/src/pages/detail/[postId].tsx
@@ -13,6 +13,8 @@ import { useRouter } from "next/router";
 import { Markdown } from "../../components/renderer";
 import { Mixpanel, TRACK } from "../../lib/mixpanel";
 import axios from "../../lib/axios";
+import Head from "next/head";
+import PLOGMeta, { OgArticle, titleTemplate } from "../../components/Head";
 
 interface Props {
   postId: number;
@@ -79,6 +81,27 @@ const Detail: NextPage<Props> = ({ postId, post }) => {
 
   return (
     <>
+      <Head>
+        <title>{titleTemplate(post.title)}</title>
+        <PLOGMeta
+          title={post.title}
+          description={post.subTitle}
+          author={"PINOT. KIM."}
+          image={""}
+          url={`https://pinot.kim/detail/${post.id}`}
+        />
+        <OgArticle
+          title={post.title}
+          description={post.subTitle}
+          author={"PINOT. KIM."}
+          image={""}
+          url={`https://pinot.kim/detail/${post.id}`}
+          publishedDate={post.createdAt}
+          modifiedDate={post.createdAt}
+          section={"Technical"}
+          tags={[]}
+        />
+      </Head>
       <Header />
       <Container>
         <PostHeader>

--- a/src/pages/detail/[postId].tsx
+++ b/src/pages/detail/[postId].tsx
@@ -14,7 +14,11 @@ import { Markdown } from "../../components/renderer";
 import { Mixpanel, TRACK } from "../../lib/mixpanel";
 import axios from "../../lib/axios";
 import Head from "next/head";
-import PLOGMeta, { OgArticle, titleTemplate } from "../../components/Head";
+import PLOGMeta, {
+  OgArticle,
+  TwitterCard,
+  titleTemplate,
+} from "../../components/Head";
 
 interface Props {
   postId: number;
@@ -100,6 +104,14 @@ const Detail: NextPage<Props> = ({ postId, post }) => {
           modifiedDate={post.createdAt}
           section={"Technical"}
           tags={[]}
+        />
+        <TwitterCard
+          url={`https://pinot.kim/detail/${post.id}`}
+          large={true}
+          title={post.title}
+          description={post.subTitle}
+          image={""}
+          imageAlt={""}
         />
       </Head>
       <Header />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,8 @@ import PostCard from "../components/PostCard";
 import Header from "../components/Header";
 import { Container } from "react-bootstrap";
 import { Mixpanel, TRACK } from "../lib/mixpanel";
+import PLOGMeta, { titleTemplate } from "../components/Head";
+import Head from "next/head";
 
 interface Props {
   posts: Post[];
@@ -42,6 +44,16 @@ const Home: NextPage<Props> = ({ posts }) => {
 
   return (
     <>
+      <Head>
+        <title>{titleTemplate("PINOT 기술 블로그")}</title>
+        <PLOGMeta
+          title={"PINOT 기술 블로그"}
+          description={"PINOT 기술 블로그"}
+          author={"PINOT. KIM."}
+          url={"https://pinot.kim"}
+          image={""}
+        />
+      </Head>
       <Header />
       <Container>
         {posts.map((post) => (


### PR DESCRIPTION
Close #40

- 🔍 기본 meta 태그 추가
- ✨  Meta Template 추가
- 🔍 Post 상세 페이지에 SEO 적용

메타 태그를 추가했으며, 이것들을 조금 더 쉽게 사용하기 위한 템플릿 파일도 추가했습니다.
